### PR TITLE
Handle PDF metadata mismatches and surface flight details

### DIFF
--- a/src/components/FeedbackDisplay.tsx
+++ b/src/components/FeedbackDisplay.tsx
@@ -27,6 +27,22 @@ const FeedbackDisplay = ({ result }: FeedbackDisplayProps) => {
     return { color: 'red', status: 'Crítico' };
   };
 
+  const { metadata } = result;
+
+  const primaryDetails = [
+    { label: 'Empresa', value: metadata?.company },
+    { label: 'Número do Voo', value: metadata?.flightNumber },
+    { label: 'Aeronave', value: metadata?.aircraft },
+    { label: 'Copiloto', value: metadata?.copilot }
+  ].filter((item) => Boolean(item.value));
+
+  const secondaryDetails = [
+    { label: 'Rota', value: metadata?.flightDetails?.route },
+    { label: 'Data', value: metadata?.flightDetails?.date },
+    { label: 'Duração', value: metadata?.flightDetails?.duration },
+    { label: 'Clima', value: metadata?.flightDetails?.weather }
+  ].filter((item) => Boolean(item.value));
+
   return (
     <div className="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
       <div className="flex items-center space-x-3 mb-6">
@@ -36,15 +52,48 @@ const FeedbackDisplay = ({ result }: FeedbackDisplayProps) => {
             Resultado da Análise
           </h3>
           <p className="text-sm text-gray-600 dark:text-gray-400">
-            ID da Transcrição: {result.transcriptId} | Piloto: {result.pilotId}
+            ID da Transcrição: {result.transcriptId}
+            {result.pilotId && ` | Piloto: ${result.pilotId}`}
           </p>
         </div>
       </div>
 
+      {(primaryDetails.length > 0 || secondaryDetails.length > 0) && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+          {primaryDetails.map((detail) => (
+            <div
+              key={detail.label}
+              className="rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/60 px-4 py-3"
+            >
+              <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                {detail.label}
+              </p>
+              <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                {detail.value}
+              </p>
+            </div>
+          ))}
+
+          {secondaryDetails.map((detail) => (
+            <div
+              key={detail.label}
+              className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white/60 dark:bg-gray-900/40 px-4 py-3"
+            >
+              <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                {detail.label}
+              </p>
+              <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                {detail.value}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+
       <div className="space-y-6">
         {result.patterns.map((pattern, index) => {
           const patternStatus = getPatternStatus(pattern.checklists);
-          
+
           return (
             <div
               key={index}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,11 +20,26 @@ export interface Pattern {
   checklists: ChecklistItem[];
 }
 
+export interface FlightMetadata {
+  company?: string;
+  flightNumber?: string;
+  aircraft?: string;
+  pilot?: string;
+  copilot?: string;
+  flightDetails?: {
+    route?: string;
+    date?: string;
+    duration?: string;
+    weather?: string;
+  };
+}
+
 export interface AnalysisResult {
   transcriptId: string;
   organizationId: string;
   pilotId: string;
   patterns: Pattern[];
+  metadata?: FlightMetadata;
 }
 
 export interface AppContextType {

--- a/src/utils/analysisFormatter.ts
+++ b/src/utils/analysisFormatter.ts
@@ -1,11 +1,41 @@
 import { AnalysisResult } from '../types';
 
 export const formatAnalysisResult = (result: AnalysisResult) => {
+  const metadataLines: string[] = [];
+
+  if (result.metadata?.company) {
+    metadataLines.push(`Empresa: ${result.metadata.company}`);
+  }
+  if (result.metadata?.flightNumber) {
+    metadataLines.push(`Número do Voo: ${result.metadata.flightNumber}`);
+  }
+  if (result.metadata?.aircraft) {
+    metadataLines.push(`Aeronave: ${result.metadata.aircraft}`);
+  }
+  if (result.metadata?.copilot) {
+    metadataLines.push(`Copiloto: ${result.metadata.copilot}`);
+  }
+
+  const details = result.metadata?.flightDetails;
+  if (details?.route) {
+    metadataLines.push(`Rota: ${details.route}`);
+  }
+  if (details?.date) {
+    metadataLines.push(`Data: ${details.date}`);
+  }
+  if (details?.duration) {
+    metadataLines.push(`Duração: ${details.duration}`);
+  }
+  if (details?.weather) {
+    metadataLines.push(`Condições Climáticas: ${details.weather}`);
+  }
+
   const header = [
     'Resultado da Análise',
     `ID da Transcrição: ${result.transcriptId}`,
     `Organização: ${result.organizationId}`,
     `Piloto: ${result.pilotId}`,
+    ...metadataLines,
     ''.trim(),
   ];
 


### PR DESCRIPTION
## Summary
- parse structured flight metadata from uploaded PDFs and reuse the pilot name in the analysis results
- warn the user when the PDF company differs from the selected organization before running the AI analysis
- surface company, flight, and route details throughout the feedback view and exported text for richer context

## Testing
- npm run lint
- npm run build *(fails: Rollup could not resolve the jspdf dependency during Vite build; existing limitation)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d0a27714832f94106a82426a8080